### PR TITLE
fix: gate Astro.csp access behind opt-in option to silence warning

### DIFF
--- a/src/Helmet.astro
+++ b/src/Helmet.astro
@@ -6,24 +6,29 @@ interface Props {
 	options?: {
 		omitHeadTags?: boolean
 		applyPriority?: (tag: Tag) => Required<Tag>
+		csp?: boolean
 	}
 }
 
 const { headItems, options = {} } = Astro.props
-const { applyPriority, omitHeadTags = false } = options
+const { applyPriority, omitHeadTags = false, csp: cspEnabled = false } = options
 const head = renderHead(headItems, applyPriority)
 
-// Register CSP hashes and resources when running on Astro 6+ with CSP enabled.
-// Cast avoids typecheck failures for downstream consumers on Astro 4/5 where
-// `csp` isn't declared on `AstroGlobal`.
-const csp = (Astro as unknown as {
-	csp?: {
-		insertScriptHash(hash: string): void
-		insertStyleHash(hash: string): void
-		insertScriptResource(url: string): void
-		insertStyleResource(url: string): void
-	}
-}).csp
+// Register CSP hashes and resources when the consumer opts in via `options.csp`
+// AND is running on Astro 6+ with CSP configured. Reading `Astro.csp` warns in
+// production when CSP isn't configured, so the opt-in keeps the component
+// silent for users who don't need CSP integration. Cast avoids typecheck
+// failures for downstream consumers on Astro 4/5.
+const csp = cspEnabled
+	? (Astro as unknown as {
+			csp?: {
+				insertScriptHash(hash: string): void
+				insertStyleHash(hash: string): void
+				insertScriptResource(url: string): void
+				insertStyleResource(url: string): void
+			}
+		}).csp
+	: undefined
 if (csp) {
 	for (const { type, content } of getInlineContent(headItems)) {
 		const hashBuffer = await crypto.subtle.digest(


### PR DESCRIPTION
## Summary
Reading `Astro.csp` is a getter that warns in production whenever CSP isn't configured (see Astro's `render-context.js`). The runtime `if (csp)` guard added in #13 fires too late — accessing the property has already triggered the warning. Result: every page render in 1.2.0 logs a noisy `[csp] Astro.csp was used ... but CSP was not configured` message for consumers who don't use CSP.

This adds an `options.csp` boolean (default `false`). The CSP integration block now only reads `Astro.csp` when the consumer explicitly opts in.

## Test plan
- [x] `npm test` (77 passing)
- [x] `npm run typecheck` (0 errors)
- [x] `npm run lint` (clean)
- [ ] Verify warning is gone in a downstream Astro 6 build (validated via willed-website)

🤖 Generated with [Claude Code](https://claude.com/claude-code)